### PR TITLE
Message queue

### DIFF
--- a/sarah/hipchat.py
+++ b/sarah/hipchat.py
@@ -4,7 +4,7 @@ import re
 from sleekxmpp import ClientXMPP, Message
 from sleekxmpp.exceptions import IqTimeout, IqError
 from typing import Dict, List, Optional, Tuple, Union
-from sarah.bot_base import BotBase, Command, enqueue
+from sarah.bot_base import BotBase, Command, concurrent, SarahException
 
 
 class HipChat(BotBase):
@@ -37,10 +37,11 @@ class HipChat(BotBase):
         def job_function():
             ret = command.execute()
             for room in command.config['rooms']:
-                self.client.send_message(
-                    mto=room,
-                    mbody=ret,
-                    mtype=command.config.get('message_type', 'groupchat'))
+                self.enqueue_sending_message(self.client.send_message,
+                                             mto=room,
+                                             mbody=ret,
+                                             mtype=command.config.get(
+                                                 'message_type', 'groupchat'))
 
         job_id = '%s.%s' % (command.module_name, command.name)
         logging.info("Add schedule %s" % id)
@@ -53,6 +54,7 @@ class HipChat(BotBase):
     def run(self) -> None:
         if not self.client.connect():
             raise SarahHipChatException('Couldn\'t connect to server.')
+        self.supervise_enqueued_message()
         self.scheduler.start()
         self.client.process(block=True)
 
@@ -104,7 +106,7 @@ class HipChat(BotBase):
         except Exception as e:
             raise SarahHipChatException('Unknown error occurred: %s.' % e)
 
-    @enqueue
+    @concurrent
     def join_rooms(self, event: Dict) -> None:
         # You MUST explicitly join rooms to receive message via XMPP interface
         for room in self.rooms:
@@ -113,7 +115,7 @@ class HipChat(BotBase):
                                                    maxhistory=None,
                                                    wait=True)
 
-    @enqueue
+    @concurrent
     def message(self, msg: Message) -> None:
         if msg['delay']['stamp']:
             # Avoid answering to all past messages when joining the room.
@@ -146,20 +148,24 @@ class HipChat(BotBase):
                                    'text': text,
                                    'from': msg['from']})
         except Exception as e:
-            msg.reply('Something went wrong with "%s"' % msg['body']).send()
+            self.enqueue_sending_message(lambda: msg.reply(
+                'Something went wrong with "%s"' % msg['body']).send())
             logging.error('Error occurred. '
                           'command: %s. input: %s. error: %s.' % (
                               command.name, msg['body'], e
                           ))
         else:
-            msg.reply(ret).send()
+            self.enqueue_sending_message(lambda: msg.reply(ret).send())
 
     def stop(self) -> None:
         super().stop()
         logging.info('STOP SCHEDULER')
         if self.scheduler.running:
-            self.scheduler.shutdown()
-            logging.info('CANCELLED SCHEDULED WORK')
+            try:
+                self.scheduler.shutdown()
+                logging.info('CANCELLED SCHEDULED WORK')
+            except Exception as e:
+                logging.error(e)
 
         logging.info('STOP HIPCHAT INTEGRATION')
         if hasattr(self, 'client') and self.client is not None:
@@ -168,5 +174,5 @@ class HipChat(BotBase):
             logging.info('DISCONNECTED FROM HIPCHAT SERVER')
 
 
-class SarahHipChatException(Exception):
+class SarahHipChatException(SarahException):
     pass

--- a/sarah/thread.py
+++ b/sarah/thread.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from concurrent.futures.thread import _WorkItem as WorkItem
+from concurrent.futures import Executor, Future
+import logging
+from queue import Queue
+import threading
+import weakref
+import atexit
+
+# Provide the same interface as ThreadPoolExecutor, but create only on thread.
+# Worker is created as daemon thread. This is done to allow the interpreter to
+# exit when there is still idle thread in ThreadExecutor (i.e. shutdown() was
+# not called). However, allowing worker to die with the interpreter has two
+# undesirable properties:
+#   - The worker would still be running during interpretor shutdown,
+#     meaning that they would fail in unpredictable ways.
+#   - The worker could be killed while evaluating a work item, which could
+#     be bad if the callable being evaluated has external side-effects e.g.
+#     writing to a file.
+#
+# To work around this problem, an exit handler is installed which tells the
+# worker to exit when its work queue is empty and then waits until the thread
+# finish.
+
+_shutdown = False
+
+
+def _python_exit():
+    global _shutdown
+    _shutdown = True
+
+
+atexit.register(_python_exit)
+
+
+def _worker(executor_reference, work_queue):
+    try:
+        while True:
+            work_item = work_queue.get(block=True)
+            if work_item is not None:
+                work_item.run()
+                continue
+            executor = executor_reference()
+            # Exit if:
+            #   - The interpreter is shutting down OR
+            #   - The executor that owns the worker has been collected OR
+            #   - The executor that owns the worker has been shutdown.
+            if _shutdown or executor is None or executor._shutdown:
+                # Notice other workers
+                work_queue.put(None)
+                return
+            del executor
+    except BaseException:
+        logging.critical('Exception in worker', exc_info=True)
+
+
+class ThreadExecuter(Executor):
+    def __init__(self):
+        """ Initialize a new ThreadExecutor instance. """
+        self._work_queue = Queue()
+        self._shutdown = False
+        self._shutdown_lock = threading.Lock()
+
+        def weakref_cb(_, q=self._work_queue):
+            q.put(None)
+
+        t = threading.Thread(target=_worker,
+                             args=(weakref.ref(self, weakref_cb),
+                                   self._work_queue))
+        t.daemon = True
+        t.start()
+        self._thread = t
+
+    def submit(self, fn, *args, **kwargs):
+        with self._shutdown_lock:
+            if self._shutdown:
+                raise RuntimeError(
+                    'cannot schedule new futures after shutdown')
+
+            f = Future()
+            w = WorkItem(f, fn, args, kwargs)
+
+            self._work_queue.put(w)
+            return f
+
+    submit.__doc__ = Executor.submit.__doc__
+
+    def shutdown(self, wait=True):
+        with self._shutdown_lock:
+            self._shutdown = True
+            self._work_queue.put(None)
+        if wait:
+            self._thread.join()
+
+    shutdown.__doc__ = Executor.shutdown.__doc__

--- a/tests/test_hipchat.py
+++ b/tests/test_hipchat.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import concurrent
+from concurrent.futures import ALL_COMPLETED
 from time import sleep
 import pytest
 import logging
@@ -153,7 +155,7 @@ class TestMessage(object):
                              ('sarah.plugins.echo',)),
                     max_workers=4)
         h.client.connect = lambda: True
-        h.client.process = lambda: True
+        h.client.process = lambda *args, **kwargs: True
         request.addfinalizer(h.stop)
 
         t = Thread(target=h.run)
@@ -161,13 +163,21 @@ class TestMessage(object):
 
         return h
 
+    def wait_future_finish(self, future):
+        sleep(.5)  # Why whould I need this line?? Check later.
+
+        ret = concurrent.futures.wait([future], 5, return_when=ALL_COMPLETED)
+        if len(ret.not_done) > 0:
+            logging.error("Jobs are not finished.")
+        assert future in ret.done
+
     def test_skip_message(self, hipchat):
         msg = Message(hipchat.client, stype='normal')
         msg['body'] = 'test body'
 
         msg.reply = MagicMock()
 
-        hipchat.message(msg)
+        self.wait_future_finish(hipchat.message(msg))
         assert msg.reply.call_count == 0
 
     def test_echo_message(self, hipchat):
@@ -176,9 +186,7 @@ class TestMessage(object):
 
         msg.reply = MagicMock()
 
-        hipchat.message(msg)
-
-        sleep(.1)
+        self.wait_future_finish(hipchat.message(msg))
         assert msg.reply.call_count == 1
         assert msg.reply.call_args == call('spam')
 
@@ -190,19 +198,16 @@ class TestMessage(object):
 
         msg.reply = MagicMock()
 
-        hipchat.message(msg)
-        sleep(.1)
+        self.wait_future_finish(hipchat.message(msg))
         assert msg.reply.call_count == 1
         assert msg.reply.call_args == call('1')
 
-        hipchat.message(msg)
-        sleep(.1)
+        self.wait_future_finish(hipchat.message(msg))
         assert msg.reply.call_count == 2
         assert msg.reply.call_args == call('2')
 
         msg['body'] = '.count egg'
-        hipchat.message(msg)
-        sleep(.1)
+        self.wait_future_finish(hipchat.message(msg))
         assert msg.reply.call_count == 3
         assert msg.reply.call_args == call('1')
 

--- a/tests/test_hipchat.py
+++ b/tests/test_hipchat.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from time import sleep
 import pytest
 import logging
 from threading import Thread
@@ -151,8 +152,12 @@ class TestMessage(object):
                     plugins=(('sarah.plugins.simple_counter', {}),
                              ('sarah.plugins.echo',)),
                     max_workers=4)
-        Thread(target=h.run)
+        h.client.connect = lambda: True
+        h.client.process = lambda: True
         request.addfinalizer(h.stop)
+
+        t = Thread(target=h.run)
+        t.start()
 
         return h
 
@@ -172,6 +177,8 @@ class TestMessage(object):
         msg.reply = MagicMock()
 
         hipchat.message(msg)
+
+        sleep(.1)
         assert msg.reply.call_count == 1
         assert msg.reply.call_args == call('spam')
 
@@ -184,15 +191,18 @@ class TestMessage(object):
         msg.reply = MagicMock()
 
         hipchat.message(msg)
+        sleep(.1)
         assert msg.reply.call_count == 1
         assert msg.reply.call_args == call('1')
 
         hipchat.message(msg)
+        sleep(.1)
         assert msg.reply.call_count == 2
         assert msg.reply.call_args == call('2')
 
         msg['body'] = '.count egg'
         hipchat.message(msg)
+        sleep(.1)
         assert msg.reply.call_count == 3
         assert msg.reply.call_args == call('1')
 


### PR DESCRIPTION
```@concurrent``` decorator allows to process multiple received messages at once by using multiple threads.
It's handy when a command takes time to complete such as accessing Web API to receive information; ```.weather tokyo``` command hits weather API and returns current weather information to chat room.
However sending back messages in the thread pool might not be safe in terms of thread-safety.
It totally depends implementation of the module the replying method is using. e.g. SleekXMPP, websocket, etc...
Instead of checking their implementations, just provide a queue to store replying messages.