### PR TITLE
Allow plugin to have context-awared conversation

### DIFF
--- a/sarah/__init__.py
+++ b/sarah/__init__.py
@@ -1,1 +1,9 @@
+from sarah import user_context, command
+
 VERSION = "0.0.1"
+
+UserContext = user_context.UserContext
+InputOption = user_context.InputOption
+
+Command = command.Command
+CommandMessage = command.CommandMessage

--- a/sarah/bot_base.py
+++ b/sarah/bot_base.py
@@ -8,48 +8,11 @@ import importlib
 import logging
 from apscheduler.schedulers.background import BackgroundScheduler
 import sys
+import re
 from typing import Callable, Optional, Sequence
+from sarah import UserContext, Command, CommandMessage
 from sarah.thread import ThreadExecutor
-from sarah.types import CommandFunction, PluginConfig, AnyFunction, \
-    CommandConfig
-
-
-class Command(object):
-    def __init__(self,
-                 name: str,
-                 function: CommandFunction,
-                 module_name: str,
-                 config: CommandConfig=None) -> None:
-        if not config:
-            config = {}
-        self.__name = name
-        self.__function = function
-        self.__module_name = module_name
-        self.__config = config
-
-    @property
-    def name(self):
-        return self.__name
-
-    @property
-    def function(self):
-        return self.__function
-
-    @property
-    def module_name(self):
-        return self.__module_name
-
-    @property
-    def config(self):
-        return self.__config
-
-    def execute(self, *args) -> str:
-        args = list(args)
-        args.append(self.__config)
-        return self.__function(*args)
-
-    def set_config(self, config: CommandConfig) -> None:
-        self.__config = config
+from sarah.types import CommandFunction, PluginConfig, AnyFunction
 
 
 class BotBase(object, metaclass=abc.ABCMeta):
@@ -62,6 +25,7 @@ class BotBase(object, metaclass=abc.ABCMeta):
         self.plugins = plugins
         self.max_workers = max_workers
         self.scheduler = BackgroundScheduler()
+        self.user_context_map = {}
 
         # To be set on run()
         self.worker = None
@@ -144,6 +108,67 @@ class BotBase(object, metaclass=abc.ABCMeta):
                                                                   e))
         else:
             logging.info('Loaded plugin. %s' % module_name)
+
+    def respond(self, user_key, user_input) -> Optional[str]:
+        user_context = self.user_context_map.pop(user_key, None)
+
+        ret = None
+        error = []
+        if user_context:
+            # If user is in the middle of conversation, check if we can proceed
+            option = next(
+                (o for o in user_context.input_options if o.match(user_input)),
+                None)
+
+            if option is None:
+                # User is not responding in the way we are expecting.
+                self.user_context_map[user_key] = user_context
+                return user_context.help_message
+
+            try:
+                ret = option.next_step(CommandMessage(original_text=user_input,
+                                                      text=user_input,
+                                                      sender=user_key))
+            except Exception as e:
+                # Error occurred, but not reassigning the user context
+                # because user may get stuck to this failing context.
+                error.append((option.next_step.__name__, str(e)))
+
+        else:
+            # If user is not in the middle of conversation, see if the input
+            # text contains command.
+            command = self.find_command(user_input)
+            if command is None:
+                # If it doesn't match any command, leave it.
+                return
+
+            try:
+                text = re.sub(r'{0}\s+'.format(command.name), '', user_input)
+                ret = command.execute(CommandMessage(original_text=user_input,
+                                                     text=text,
+                                                     sender=user_key))
+            except Exception as e:
+                error.append((command.name, str(e)))
+
+        if error:
+            logging.error('Error occurred. '
+                          'command: %s. input: %s. error: %s.' % (
+                              error[0][0], user_input, error[0][1]
+                          ))
+            return 'Something went wrong with "%s"' % user_input
+
+        elif not ret:
+            logging.error('command should return UserContext or text'
+                          'to let user know the result or next move')
+            return 'Something went wrong with "%s"' % user_input
+
+        elif isinstance(ret, UserContext):
+            self.user_context_map[user_key] = ret
+            return ret.message
+
+        else:
+            # String
+            return ret
 
     def find_command(self, text: str) -> Optional[Command]:
         # Find the first registered command that matches the input text

--- a/sarah/command.py
+++ b/sarah/command.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from typing import Union
+from sarah.types import CommandFunction, CommandConfig
+from sarah.user_context import UserContext
+
+
+class Command(object):
+    def __init__(self,
+                 name: str,
+                 function: CommandFunction,
+                 module_name: str,
+                 config: CommandConfig=None) -> None:
+        if not config:
+            config = {}
+        self.__name = name
+        self.__function = function
+        self.__module_name = module_name
+        self.__config = config
+
+    @property
+    def name(self):
+        return self.__name
+
+    @property
+    def function(self):
+        return self.__function
+
+    @property
+    def module_name(self):
+        return self.__module_name
+
+    @property
+    def config(self):
+        return self.__config
+
+    def execute(self, *args) -> Union[UserContext, str]:
+        args = list(args)
+        args.append(self.config)
+        return self.function(*args)
+
+    def set_config(self, config: CommandConfig) -> None:
+        self.__config = config
+
+
+class CommandMessage:
+    def __init__(self, original_text: str, text: str, sender: str):
+        self.__original_text = original_text
+        self.__text = text
+        self.__sender = sender
+
+    @property
+    def original_text(self):
+        return self.__original_text
+
+    @property
+    def text(self):
+        return self.__text
+
+    @property
+    def sender(self):
+        return self.__sender

--- a/sarah/plugins/bmw_quotes.py
+++ b/sarah/plugins/bmw_quotes.py
@@ -2,6 +2,7 @@
 
 import random
 from typing import Dict
+from sarah import CommandMessage
 from sarah.hipchat import HipChat
 from sarah.slack import Slack
 
@@ -32,7 +33,7 @@ quotes = (("Eric: So I said to myself, 'Kyle,'\n"
 
 # noinspection PyUnusedLocal
 @HipChat.command('.bmw')
-def hipchat_quote(msg: HipChat.CommandMessage, config: Dict) -> str:
+def hipchat_quote(msg: CommandMessage, config: Dict) -> str:
     return random.choice(quotes)
 
 
@@ -44,7 +45,7 @@ def hipchat_scheduled_quote(config: Dict) -> str:
 
 # noinspection PyUnusedLocal
 @Slack.command('.bmw')
-def slack_quote(msg: Slack.CommandMessage, config: Dict) -> str:
+def slack_quote(msg: CommandMessage, config: Dict) -> str:
     return random.choice(quotes)
 
 

--- a/sarah/plugins/echo.py
+++ b/sarah/plugins/echo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import Dict
+from sarah import CommandMessage
 
 from sarah.hipchat import HipChat
 from sarah.slack import Slack
@@ -7,11 +8,11 @@ from sarah.slack import Slack
 
 # noinspection PyUnusedLocal
 @HipChat.command('.echo')
-def hipchat_echo(msg: HipChat.CommandMessage, config: Dict) -> str:
+def hipchat_echo(msg: CommandMessage, config: Dict) -> str:
     return msg.text
 
 
 # noinspection PyUnusedLocal
 @Slack.command('.echo')
-def slack_echo(msg: Slack.CommandMessage, config: Dict) -> str:
+def slack_echo(msg: CommandMessage, config: Dict) -> str:
     return msg.text

--- a/sarah/plugins/hello.py
+++ b/sarah/plugins/hello.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from typing import Dict
+from sarah import UserContext, InputOption, CommandMessage
+from sarah.hipchat import HipChat
+
+
+# noinspection PyUnusedLocal
+@HipChat.command('.hello')
+def hipchat_hello(msg: CommandMessage, config: Dict) -> UserContext:
+    # Return UserContext to start conversation. State will be stored for later
+    # user interaction.
+    return UserContext(message="Hello. How are you feeling today?",
+                       help_message="Say Good or Bad, please.",
+                       input_options=(
+                           InputOption("Good", hipchat_user_feeling_good),
+                           InputOption("Bad", hipchat_user_feeling_bad)))
+
+
+def hipchat_user_feeling_good(_: CommandMessage) -> str:
+    # Just return text to reply and end conversation.
+    return "Good to hear that."
+
+
+def hipchat_user_feeling_bad(_: CommandMessage) -> UserContext:
+    # Return UserContext instance to continue the conversation
+    return UserContext(message="Are you sick?",
+                       help_message="Say Yes or No, please.",
+                       input_options=(
+                           InputOption("Yes", hipchat_user_sick),
+                           InputOption("No", hipchat_user_not_sick)))
+
+
+def hipchat_user_sick(_: CommandMessage) -> str:
+    return "I'm sorry to hear that. Hope you get better, soon."
+
+
+def hipchat_user_not_sick(_: CommandMessage) -> str:
+    return "So you are just not feeling well. O.K., then."

--- a/sarah/plugins/simple_counter.py
+++ b/sarah/plugins/simple_counter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import Dict
+from sarah import CommandMessage
 
 from sarah.hipchat import HipChat
 from sarah.slack import Slack
@@ -25,25 +26,25 @@ def reset_count(bot_type: str) -> None:
 
 # noinspection PyUnusedLocal
 @HipChat.command('.count')
-def hipchat_count(msg: HipChat.CommandMessage, config: Dict) -> str:
+def hipchat_count(msg: CommandMessage, config: Dict) -> str:
     return str(count('hipchat', msg.sender, msg.text))
 
 
 # noinspection PyUnusedLocal
 @HipChat.command('.reset_count')
-def hipchat_reset_count(msg: HipChat.CommandMessage, config: Dict) -> str:
+def hipchat_reset_count(msg: CommandMessage, config: Dict) -> str:
     reset_count('hipchat')
     return 'restart counting'
 
 
 # noinspection PyUnusedLocal
 @Slack.command('.count')
-def slack_count(msg: HipChat.CommandMessage, config: Dict) -> str:
+def slack_count(msg: CommandMessage, config: Dict) -> str:
     return str(count('slack', msg.sender, msg.text))
 
 
 # noinspection PyUnusedLocal
 @Slack.command('.reset_count')
-def slack_reset_count(msg: HipChat.CommandMessage, config: Dict) -> str:
+def slack_reset_count(msg: CommandMessage, config: Dict) -> str:
     reset_count('slack')
     return 'restart counting'

--- a/sarah/user_context.py
+++ b/sarah/user_context.py
@@ -48,6 +48,3 @@ class UserContext(object):
     @property
     def input_options(self) -> Sequence[InputOption]:
         return self.__input_options
-
-    def receive_input(self):
-        return

--- a/sarah/user_context.py
+++ b/sarah/user_context.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from typing import Callable, Pattern, Union, AnyStr
+from typing import Sequence
+import re
+
+
+class InputOption(object):
+    def __init__(self,
+                 pattern: Union[Pattern, AnyStr],
+                 next_step: Callable) -> None:
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
+        self.__pattern = pattern
+        self.__next_step = next_step
+
+    @property
+    def pattern(self) -> Pattern:
+        return self.__pattern
+
+    @property
+    def next_step(self) -> Callable:
+        return self.__next_step
+
+    def match(self, msg: str) -> bool:
+        return self.pattern.match(msg)
+
+
+class UserContext(object):
+    def __init__(self,
+                 message: str,
+                 help_message: str,
+                 input_options: Sequence[InputOption]) -> None:
+        self.__message = message
+        self.__help_message = help_message
+        self.__input_options = input_options
+
+    def __str__(self):
+        return self.message
+
+    @property
+    def message(self) -> str:
+        return self.__message
+
+    @property
+    def help_message(self) -> str:
+        return self.__help_message
+
+    @property
+    def input_options(self) -> Sequence[InputOption]:
+        return self.__input_options
+
+    def receive_input(self):
+        return

--- a/tests/test_hipchat.py
+++ b/tests/test_hipchat.py
@@ -11,7 +11,8 @@ from sleekxmpp.stanza import Message
 from sleekxmpp.exceptions import IqTimeout, IqError
 from sleekxmpp.xmlstream import JID
 from mock import MagicMock, call, patch
-from sarah.hipchat import HipChat, SarahHipChatException, CommandMessage
+from sarah import CommandMessage
+from sarah.hipchat import HipChat, SarahHipChatException
 import sarah.plugins.simple_counter
 import types
 

--- a/tests/test_hipchat_plugin.py
+++ b/tests/test_hipchat_plugin.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from sarah import CommandMessage
+from sarah import CommandMessage, UserContext
 from sarah.plugins.echo import hipchat_echo
+from sarah.plugins.hello import hipchat_hello, hipchat_user_feeling_good, \
+    hipchat_user_feeling_bad
 from sarah.plugins.simple_counter import hipchat_count, hipchat_reset_count, \
     reset_count
 from sarah.plugins.bmw_quotes import hipchat_quote
@@ -74,3 +76,24 @@ class TestBMWQuotes(object):
                              sender='123_homer@localhost/Oklahomer')
         response = hipchat_quote(msg, {})
         assert (response in sarah.plugins.bmw_quotes.quotes) is True
+
+
+class TestHello(object):
+    def test__init(self):
+        msg = CommandMessage(original_text='.hello',
+                             text='',
+                             sender='spam@localhost/ham')
+        response = hipchat_hello(msg, {})
+        assert isinstance(response, UserContext) is True
+        assert response.message == "Hello. How are you feeling today?"
+        assert len(response.input_options) == 2
+        assert (response.input_options[0].next_step.__name__ ==
+                hipchat_user_feeling_good.__name__)
+        assert (response.input_options[1].next_step.__name__ ==
+                hipchat_user_feeling_bad.__name__)
+
+        assert (response.input_options[0].next_step("Good") ==
+                "Good to hear that.")
+
+        isinstance(response.input_options[1].next_step("Bad"),
+                   UserContext) is True

--- a/tests/test_hipchat_plugin.py
+++ b/tests/test_hipchat_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from sarah.hipchat import CommandMessage
+from sarah import CommandMessage
 from sarah.plugins.echo import hipchat_echo
 from sarah.plugins.simple_counter import hipchat_count, hipchat_reset_count, \
     reset_count

--- a/tests/test_slack_plugin.py
+++ b/tests/test_slack_plugin.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+from sarah import CommandMessage
 from sarah.plugins.bmw_quotes import slack_quote
 from sarah.plugins.echo import slack_echo
 from sarah.plugins.simple_counter import reset_count, slack_count, \
     slack_reset_count
-from sarah.slack import CommandMessage
 import sarah.plugins.bmw_quotes
 
 


### PR DESCRIPTION
1. User may start conversation by providing message input just like regular command.
2. Plugin may return UserContext instance that contains more than one InputOption: a set of allowed input and corresponding method.
3. When user input allowed message, associated method is called with this message as argument.
 - If no matching InputOption is found, it automatically returns UserContext#help_message to let user re-input.
4. Return UserContext to continue conversation, or return message string to respond and quit conversation.